### PR TITLE
Better interrupted handling for #11

### DIFF
--- a/core/src/main/java/org/smpp/util/ProcessingThread.java
+++ b/core/src/main/java/org/smpp/util/ProcessingThread.java
@@ -147,7 +147,7 @@ public abstract class ProcessingThread extends SmppObject implements Runnable {
 				try {
 					Thread.sleep(100); // we're waiting for the proc thread to start
 				} catch (InterruptedException e) {
-					event.write(e, e.getMessage());
+					Thread.currentThread().interrupt();
 				}
 			}
 		}
@@ -166,7 +166,7 @@ public abstract class ProcessingThread extends SmppObject implements Runnable {
 				try {
 					Thread.sleep(100); // we're waiting for the proc thread to stop
 				} catch (InterruptedException e) {
-					event.write(e, e.getMessage());
+					Thread.currentThread().interrupt();
 				}
 			}
 		}


### PR DESCRIPTION
Safer interrupted handling. Removed logging, which was only potentially interesting while the
interruption was being swallowed.