### PR TITLE
Remove boomerang link to Logica's OpenSMPP page

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,8 +11,7 @@ layout: default
 
 OpenSmpp is a mature Java library implementing the SMPP protocol,
 and allowing development of External Short Message Entities (ESMEs)
-and more. It is based on the original
-[Logica OpenSMPP API](http://opensmpp.logica.com/).
+and more. It is based on the original Logica OpenSMPP API.
 
 ## Requirements
 


### PR DESCRIPTION
http://opensmpp.logica.com/ redirects right back to this page, so no point providing that link now.