### PR TITLE
Make it substantially easier to execute the simulator and client

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -11,10 +11,43 @@
 	<packaging>jar</packaging>
 	<name>OpenSMPP Client</name>
 
+	<properties>
+		<app.mainClass>org.smpp.test.SMPPTest</app.mainClass>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>opensmpp-core</artifactId>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<createDependencyReducedPom>false</createDependencyReducedPom>
+					<transformers>
+						<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+						<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+							<manifestEntries>
+								<Main-Class>${app.mainClass}</Main-Class>
+							</manifestEntries>
+						</transformer>
+					</transformers>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/client/src/main/bin/smppsender.bat
+++ b/client/src/main/bin/smppsender.bat
@@ -1,1 +1,0 @@
-java -classpath smpp.jar org.smpp.client.SMPPSender %1 %2 %3 %4 %5 %6 %7 %8 %9

--- a/client/src/main/bin/smppsender.sh
+++ b/client/src/main/bin/smppsender.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-java -classpath smpp.jar org.smpp.client.SMPPSender $1 $2 $3 $4 $5 $6 $7 $8 $9

--- a/sim/pom.xml
+++ b/sim/pom.xml
@@ -11,10 +11,43 @@
 	<packaging>jar</packaging>
 	<name>OpenSMPP Simulator</name>
 
+	<properties>
+		<app.mainClass>org.smpp.smscsim.Simulator</app.mainClass>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>opensmpp-core</artifactId>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<createDependencyReducedPom>false</createDependencyReducedPom>
+					<transformers>
+						<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+						<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+							<manifestEntries>
+								<Main-Class>${app.mainClass}</Main-Class>
+							</manifestEntries>
+						</transformer>
+					</transformers>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
This bundles the simulator and client as fat-JARs, with a manifest entry for the appropriate main class. Executing the applications is now as simple as `java -jar ...`