### PR TITLE
Improvements: .gitignore, handling of character encoding in sim and client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,20 @@ target
 .settings
 .classpath
 .DS_Store
+hs_err_pid*
+
+# Log files by simulator
+*.dbg0
+*.evt0
+
+# Used by simulator
+sim/etc/users.txt
+
+# Eclipse
+**/.settings/
+**/.classpath
+**/.project
+
+# IntelliJ
+**/*.iml
+.idea

--- a/client/src/main/java/org/smpp/client/SMPPSender.java
+++ b/client/src/main/java/org/smpp/client/SMPPSender.java
@@ -22,6 +22,7 @@ import org.smpp.pdu.SubmitSM;
 import org.smpp.pdu.SubmitSMResp;
 import org.smpp.pdu.UnbindResp;
 import org.smpp.pdu.WrongLengthOfStringException;
+import org.smpp.util.DataCodingCharsetHandler;
 
 /**
  * Class <code>SMPPTest</code> shows how to use the SMPP toolkit.
@@ -320,7 +321,9 @@ public class SMPPSender {
 			}
 			request.setDestAddr(new Address((byte)1, (byte)1, destAddress));
 			request.setReplaceIfPresentFlag(replaceIfPresentFlag);
-			request.setShortMessage(shortMessage,Data.ENC_GSM7BIT);
+
+			String encoding = DataCodingCharsetHandler.getCharsetName(dataCoding);
+			request.setShortMessage(shortMessage, encoding);
 			request.setScheduleDeliveryTime(scheduleDeliveryTime);
 			request.setValidityPeriod(validityPeriod);
 			request.setEsmClass(esmClass);

--- a/core/src/main/java/org/smpp/util/DataCodingCharsetHandler.java
+++ b/core/src/main/java/org/smpp/util/DataCodingCharsetHandler.java
@@ -1,0 +1,43 @@
+package org.smpp.util;
+
+import org.smpp.Data;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Handles charset handling based on <code>data_coding</code> parameter, see
+ * SMPP 3.4 specification, paragraph 5.2.19
+ */
+public class DataCodingCharsetHandler {
+	private static final Map<Byte, String> DATA_CODING_CHARSET;
+
+	static {
+		DATA_CODING_CHARSET = new HashMap<Byte, String>();
+		DATA_CODING_CHARSET.put((byte) 0, Data.ENC_GSM7BIT);
+		DATA_CODING_CHARSET.put((byte) 8, Data.ENC_UTF16);
+	}
+
+	/**
+	 * Return the correct charset given the <code>data_coding</code> parameter.
+	 * If none is found it defaults to <code>X-Gsm7Bit</code>.
+	 *
+	 * @param dataCoding
+	 * @return encoding name
+	 */
+	public static String getCharsetName(byte dataCoding) {
+		return getCharsetName(dataCoding, Data.ENC_GSM7BIT);
+	}
+
+	/**
+	 * Return the correct charset given the <code>data_coding</code> parameter.
+	 *
+	 * @param dataCoding
+	 * @param defaultEncoding
+	 * @return encoding name
+	 */
+	public static String getCharsetName(byte dataCoding, String defaultEncoding) {
+		String encoding = DATA_CODING_CHARSET.get(dataCoding);
+		return encoding != null ? encoding : defaultEncoding;
+	}
+}

--- a/sim/src/main/java/org/smpp/smscsim/ShortMessageStore.java
+++ b/sim/src/main/java/org/smpp/smscsim/ShortMessageStore.java
@@ -10,6 +10,7 @@
  */
 package org.smpp.smscsim;
 
+import java.io.UnsupportedEncodingException;
 import java.util.Enumeration;
 import java.util.Hashtable;
 
@@ -48,7 +49,7 @@ public class ShortMessageStore {
 	 * @see ShortMessageValue
 	 * @see org.smpp.pdu.SubmitSM
 	 */
-	public synchronized void submit(SubmitSM message, String messageId, String systemId) {
+	public synchronized void submit(SubmitSM message, String messageId, String systemId) throws UnsupportedEncodingException {
 		messages.put(messageId, new ShortMessageValue(systemId, message));
 	}
 

--- a/sim/src/main/java/org/smpp/smscsim/ShortMessageValue.java
+++ b/sim/src/main/java/org/smpp/smscsim/ShortMessageValue.java
@@ -11,6 +11,9 @@
 package org.smpp.smscsim;
 
 import org.smpp.pdu.SubmitSM;
+import org.smpp.util.DataCodingCharsetHandler;
+
+import java.io.UnsupportedEncodingException;
 
 /**
  * Class for storing a subset of attributes of messages to a message store.
@@ -32,12 +35,14 @@ class ShortMessageValue {
 	 * @param systemId system id of the client
 	 * @param submit the PDU send from the client
 	 */
-	ShortMessageValue(String systemId, SubmitSM submit) {
+	ShortMessageValue(String systemId, SubmitSM submit) throws UnsupportedEncodingException {
 		this.systemId = systemId;
 		serviceType = submit.getServiceType();
 		sourceAddr = submit.getSourceAddr().getAddress();
 		destinationAddr = submit.getDestAddr().getAddress();
-		shortMessage = submit.getShortMessage();
+
+		String encoding = DataCodingCharsetHandler.getCharsetName(submit.getDataCoding());
+		shortMessage = submit.getShortMessage(encoding);
 	}
 }
 /*

--- a/sim/src/main/java/org/smpp/smscsim/Simulator.java
+++ b/sim/src/main/java/org/smpp/smscsim/Simulator.java
@@ -22,6 +22,7 @@ import org.smpp.smscsim.SimulatorPDUProcessorFactory;
 import org.smpp.smscsim.util.Table;
 
 /**
+ * <p>
  * Class <code>Simulator</code> is an application class behaving as a real
  * SMSC with SMPP interface.
  * Clients (ESMEs) can bind to it, send requests to which this application
@@ -34,14 +35,21 @@ import org.smpp.smscsim.util.Table;
  * <p>
  * This simulator application uses <code>SimulatorPDUProcessor</code> to process
  * the PDUs received from the clients.
+ * </p>
  * <p>
  * To run this application using <b>smpp.jar</b> and <b>smscsim.jar</b> library files execute
  * the following command:
- * <p>
- * <code>java -cp smpp.jar:smscsim.jar org.smpp.smscsim.Simulator</code>
+ * </p>
+ * <pre>
+ * java -cp smpp.jar:smscsim.jar org.smpp.smscsim.Simulator
+ * </pre>
  * <p>
  * If your libraries are stored in other that default directory, use the
  * directory name in the <code>-cp</code> argument.
+ * </p>
+ * <p>
+ * User file can be specified using <code>usersFileName</code> property, e.g.: <code>-DusersFileName=/my/path/to/users.txt</code>
+ * </p>
  * 
  * @author Logica Mobile Networks SMPP Open Source Team
  * @version $Id: Simulator.java 72 2008-07-15 19:43:00Z sverkera $
@@ -64,7 +72,7 @@ public class Simulator {
 	/**
 	 * Name of file with user (client) authentication information.
 	 */
-	static String usersFileName = "etc/users.txt";
+	static String usersFileName = System.getProperty("usersFileName", "etc/users.txt");
 
 	/**
 	 * Directory for creating of debug and event files.


### PR DESCRIPTION
These modifications attempt to *improve developer experience* for people trying out OpenSmpp:

# `.gitignore`

- added some filters for common IDEs: Eclipse, JetBrains IntelliJ
- filter log files produced by simulator (`org.smpp.smscsim.Simulator`) and test client (`org.smpp.test.SMPPTest`), i.e. `*.dbg0`, `*.evt0`

# `DataCodingCharsetHandler`

Attempt to standardize handling of text encoding based on `data_coding` parameter of SMPP PDUs.
This POC handles only `X-Gsm7Bit` and `UTF-16`