### PR TITLE
Decrease COMMS_TIMEOUT and QUEUE_TIMEOUT to fix slow shutdown

### DIFF
--- a/core/src/main/java/org/smpp/Data.java
+++ b/core/src/main/java/org/smpp/Data.java
@@ -540,8 +540,8 @@ public class Data {
 	// all times in milliseconds
 	public static final long RECEIVER_TIMEOUT = 60000;
 	public static final long CONNECTION_RECEIVE_TIMEOUT = 10000;
-	public static final long COMMS_TIMEOUT = 60000;
-	public static final long QUEUE_TIMEOUT = 10000;
+	public static final long COMMS_TIMEOUT = 2000; // See https://github.com/OpenSmpp/opensmpp/issues/33
+	public static final long QUEUE_TIMEOUT = 2000; // See https://github.com/OpenSmpp/opensmpp/issues/33
 	public static final long ACCEPT_TIMEOUT = 60000;
 	public static final int CONNECTION_TIMEOUT = 60000;
 

--- a/core/src/test/java/org/smpp/ClientSessionUnbindIT.java
+++ b/core/src/test/java/org/smpp/ClientSessionUnbindIT.java
@@ -94,7 +94,9 @@ public class ClientSessionUnbindIT extends SmppObject {
 		clientEvent("connecting");
 		TCPIPConnection clientConnection = new TCPIPConnection("127.0.0.1", listenPort);
 		clientConnection.setReceiveTimeout(2 * 1000);
-		clientConnection.setCommsTimeout(1 * 1000);
+		// The setting is especially detrimental to quick client shutdowns on unbind, but the global
+		// setting is low enough to limit the impact: https://github.com/OpenSmpp/opensmpp/issues/33
+		clientConnection.setCommsTimeout(Data.COMMS_TIMEOUT);
 
 		clientSession = new Session(clientConnection);
 		clientSession.open();

--- a/core/src/test/java/org/smpp/TestServer.java
+++ b/core/src/test/java/org/smpp/TestServer.java
@@ -25,9 +25,9 @@ class TestServer extends SmppObject implements Runnable {
 	private long receiverReceiveTimeout = GLOBAL_DEFAULT_TIMEOUT;
 	private long acceptedSocketCommsTimeout = GLOBAL_DEFAULT_TIMEOUT;
 	private long acceptedSocketReceiveTimeout = GLOBAL_DEFAULT_TIMEOUT;
-	// This setting is especially detrimental to quick server shutdowns, and seems harmless to
-	// decrease (should have zero negative effect):
-	private long receiverQueueWaitTimeout = 1 * 1000;
+	// This setting is especially detrimental to quick server shutdowns (but the global default is
+	// low enough to limit the impact: https://github.com/OpenSmpp/opensmpp/issues/33)
+	private long receiverQueueWaitTimeout = Data.QUEUE_TIMEOUT;
 	
 	public void stop() {
 		this.keepRunning = false;


### PR DESCRIPTION
Hopefully fixes #33 