### PR TITLE
Adding TLS capabilities to client and server, modifications to Connec…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: java
 jdk:
-  - oraclejdk8
-  - openjdk7
+  - openjdk8

--- a/client/src/main/java/org/smpp/client/SMPPSender.java
+++ b/client/src/main/java/org/smpp/client/SMPPSender.java
@@ -8,7 +8,9 @@ import java.util.Iterator;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
+import org.smpp.Connection;
 import org.smpp.Data;
+import org.smpp.SSLConnection;
 import org.smpp.Session;
 import org.smpp.TCPIPConnection;
 import org.smpp.pdu.Address;
@@ -55,6 +57,11 @@ public class SMPPSender {
 	 * If the application is bound to the SMSC.
 	 */
 	boolean bound = false;
+
+	/**
+	 * If application should use TLS.
+	 */
+	private static boolean useTLS = false;
 
 	/**
 	 * Address of the SMSC.
@@ -155,6 +162,8 @@ public class SMPPSender {
 					message = args[++i];
 				} else if(opt.compareToIgnoreCase("file") == 0) {
 					propsFilePath = args[++i];
+				} else if(opt.compareToIgnoreCase("tls") == 0) {
+					useTLS = true;
 				}
 			}
 		}
@@ -224,7 +233,12 @@ public class SMPPSender {
 
 			request = new BindTransmitter();
 
-			TCPIPConnection connection = new TCPIPConnection(ipAddress, port);
+			Connection connection;
+			if(useTLS) {
+				connection = new SSLConnection(ipAddress, port);
+			} else {
+				connection = new TCPIPConnection(ipAddress, port);
+			}
 			connection.setReceiveTimeout(20 * 1000);
 			session = new Session(connection);
 

--- a/core/src/main/java/org/smpp/Connection.java
+++ b/core/src/main/java/org/smpp/Connection.java
@@ -15,6 +15,8 @@ import java.io.IOException;
 import org.smpp.Data;
 import org.smpp.util.ByteBuffer;
 
+import javax.net.SocketFactory;
+
 /**
  * Abstract class defining necessary abstract methods for communication
  * over socket based network communication interface. It defines methods
@@ -176,6 +178,12 @@ public abstract class Connection extends SmppObject {
 	public String getAddress() {
 		return address;
 	}
+
+	/**
+	 * Create method to get SocketFactory to override the variable hiding
+	 * in SSLConnection. Use to get SSLSocketFactory instead of defaultSocketFactory
+	 */
+	public abstract SocketFactory getSocketFactory();
 }
 
 /*

--- a/core/src/main/java/org/smpp/SSLConnection.java
+++ b/core/src/main/java/org/smpp/SSLConnection.java
@@ -67,4 +67,20 @@ public class SSLConnection extends TCPIPConnection {
 	public SSLConnection(SSLSocket sslsocket) throws IOException {
 		super(sslsocket);
 	}
+
+	/**
+	 * Create method to get SocketFactory to override the variable hiding
+	 * in SSLConnection. Use to get SSLSocketFactory instead of defaultSocketFactory
+	 */
+	public SocketFactory getSocketFactory() {
+		return this.socketFactory;
+	}
+
+	/**
+	 * Create method to get SocketFactory to override the variable hiding
+	 * in SSLConnection. Use to get SSLSocketFactory instead of defaultServerSocketFactory
+	 */
+	public ServerSocketFactory getServerSocketFactory() {
+		return this.serverSocketFactory;
+	}
 }

--- a/sim/src/main/java/org/smpp/smscsim/SMSCListenerImpl.java
+++ b/sim/src/main/java/org/smpp/smscsim/SMSCListenerImpl.java
@@ -14,6 +14,7 @@ import java.io.InterruptedIOException;
 import java.io.IOException;
 
 import org.smpp.Connection;
+import org.smpp.SSLConnection;
 import org.smpp.SmppObject;
 
 /**
@@ -72,7 +73,12 @@ public class SMSCListenerImpl extends SmppObject implements Runnable, SMSCListen
 	public synchronized void start() throws IOException {
 		debug.write("going to start SMSCListener on port " + port);
 		if (!isReceiving) {
-			serverConn = new org.smpp.TCPIPConnection(port);
+			if(System.getProperty("javax.net.ssl.keyStore") == null || System.getProperty("javax.net.ssl.keyStorePassword") == null ||
+					System.getProperty("javax.net.ssl.keyStore").equals("") || System.getProperty("javax.net.ssl.keyStorePassword").equals("") ) {
+				serverConn = new org.smpp.TCPIPConnection(port);
+			} else {
+				serverConn = new org.smpp.SSLConnection(port);
+			}
 			serverConn.setReceiveTimeout(getAcceptTimeout());
 			serverConn.open();
 			keepReceiving = true;


### PR DESCRIPTION
…tion classes

Using an SSLConnection was not possible because it was being referenced within TCPIPConnection without a getter. Added getters to allow overriding.
Added use of SSL to server and client. In Simulator, an SSL connection is used if the keystore and keystore password are provided. In SMPPSender, an SSL connection is used if "tls" is a command line arg. For anyone not using those options, functionality does not change it all.